### PR TITLE
FEAT: Temparature convert implementation. Clap usage implement for temp.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,242 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "convert-rs"
 version = "0.1.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap={ version = "4.5.37", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,40 @@
+pub mod units;
+
+use units::convertible::Convertible;
+use units::degrees::{Celsius, Fahrenheit, Kelvin};
+
+pub fn convert_temperature(value: f64, from: &str, to: &str) -> Option<f64> {
+    let from = from.to_lowercase();
+    let to = to.to_lowercase();
+
+    match from.as_str() {
+        "celsius" => Celsius { value }.convert(&to),
+        "fahrenheit" => Fahrenheit { value }.convert(&to),
+        "kelvin" => Kelvin { value }.convert(&to),
+        _ => None,
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_celsius_to_fahrenheit() {
+        assert_eq!(convert_temperature(0.0, "Celsius", "Fahrenheit"), Some(32.0));
+    }
+
+    #[test]
+    fn test_fahrenheit_to_celsius() {
+        assert_eq!(convert_temperature(32.0, "Fahrenheit", "Celsius"), Some(0.0));
+    }
+
+    #[test]
+    fn test_kelvin_to_celsius() {
+        assert_eq!(convert_temperature(273.15, "Kelvin", "Celsius"), Some(0.0));
+    }
+
+    #[test]
+    fn test_invalid_unit() {
+        assert_eq!(convert_temperature(100.0, "Celsius", "Banane"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,34 @@
-fn main() {
+use clap::Parser;
+use convert_rs::convert_temperature;
 
-    
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+#[command(name = "convert-rs", version, about = "Unit conversion CLI tool")]
+struct Cli {
+    /// Temperature value to convert
+    #[clap(value_parser)]
+    value: f64,
+
+    /// Unit to convert from
+    #[clap(value_parser)]
+    from: String,
+
+    /// Unit to convert to
+    #[clap(value_parser)]
+    to: String,
+}
+
+
+fn main() {
+    let cli = Cli::parse();
+
+    let value = cli.value;
+    let from = cli.from.to_lowercase();
+    let to = cli.to.to_lowercase();
+
+    match convert_temperature(value, &from, &to) {
+        Some(result) => println!("Converted value: {} {} = {} {}", value, from, result, to),
+        None => println!("Invalid conversion from {} to {}", from, to),
+    }
+
 }

--- a/src/units/convertible.rs
+++ b/src/units/convertible.rs
@@ -1,0 +1,3 @@
+pub trait Convertible {
+    fn  convert(&self, to: &str) -> Option<f64>; //Option = some or none
+}

--- a/src/units/degrees.rs
+++ b/src/units/degrees.rs
@@ -1,0 +1,43 @@
+use super::convertible::Convertible;
+
+pub struct Celsius {
+    pub value: f64,
+}
+
+pub struct Fahrenheit {
+    pub value: f64,
+}
+
+pub struct Kelvin {
+    pub value: f64,
+}
+
+impl Convertible for Celsius {
+    fn convert(&self, to: &str) -> Option<f64> {
+        match to {
+            "fahrenheit" => Some(self.value * 9.0 / 5.0 + 32.0),
+            "kelvin" => Some(self.value + 273.15),
+            _ => None,
+        }
+    }
+}
+
+impl Convertible for Fahrenheit {
+    fn convert(&self, to: &str) -> Option<f64> {
+        match to {
+            "celsius" => Some((self.value - 32.0) * 5.0 / 9.0),
+            "kelvin" => Some((self.value - 32.0) * 5.0 / 9.0 + 273.15),
+            _ => None,
+        }
+    }
+}
+
+impl Convertible for Kelvin {
+    fn convert(&self, to: &str) -> Option<f64> {
+        match to {
+            "celsius" => Some(self.value - 273.15),
+            "fahrenheit" => Some((self.value - 273.15) * 9.0 / 5.0 + 32.0),
+            _ => None,
+        }
+    }
+}

--- a/src/units/mod.rs
+++ b/src/units/mod.rs
@@ -1,0 +1,3 @@
+pub mod convertible;
+pub mod degrees;
+


### PR DESCRIPTION
### ✅ Objectif

Première implémentation de la logique métier pour la conversion d’unités de température.  
Cette PR ajoute :

- Le trait `Convertible` (définit le comportement de conversion)
- Les structures `Celsius`, `Fahrenheit`, `Kelvin` et leurs implémentations
- Le fichier `lib.rs` pour regrouper la logique
- L’entrée CLI via `clap` dans `main.rs` (avec parsing des arguments)
- 4 tests unitaires valides pour vérifier la conversion

<img width="713" alt="image" src="https://github.com/user-attachments/assets/18981602-e859-4f95-85ea-8cf9ace46f59" />

### 📁 Contenu

- `units/convertible.rs` : Trait commun
- `units/degrees.rs` : Implémentation des températures
- `lib.rs` : Point d’entrée métier
- `main.rs` : Interface utilisateur CLI avec `clap`


### 🧪 Tests

✅ Tous les tests passent via `cargo test` :

<img width="979" alt="image" src="https://github.com/user-attachments/assets/7f2d1d52-462e-4a28-86a9-a3278d923f37" />


### 🔧 À venir

- Support d'autres unités (`distance`, ect)
- Structuration de l’option `--list` pour afficher les unités disponibles



